### PR TITLE
Reformatted abstract according to convention

### DIFF
--- a/lib/opts.pm
+++ b/lib/opts.pm
@@ -189,7 +189,7 @@ __END__
 
 =head1 NAME
 
-(DEPRECATED)opts - simple command line option parser
+opts - (DEPRECATED) simple command line option parser
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
Hi,

I've tweaked the formatting of the abstract (=head1 NAME section in pod). If you don't follow the expected format, then various tools don't find the abstract in the pod. For example MetaCPAN then doesn't present the module in the usual way.

Given you've deprecated the module, it's less important, but I'm working through all dists that cause this problem for MetaCPAN.

Cheers,
Neil
