### PR TITLE
Adapt to changes in Getopt-Long-2.58

### DIFF
--- a/t/010_simple/02_type.t
+++ b/t/010_simple/02_type.t
@@ -7,7 +7,7 @@ use Test::Exception;
 @ARGV = qw(--foo=3);
 is foo(), 6;
 @ARGV = qw(--foo=3.14);
-throws_ok { foo() } qr/Value "3.14" invalid for option foo \(number expected\)/;
+throws_ok { foo() } qr/Value "3.14" invalid for option foo \((integer )?number expected\)/;
 done_testing;
 exit;
 

--- a/t/010_simple/06_required_tc.t
+++ b/t/010_simple/06_required_tc.t
@@ -43,6 +43,6 @@ lives_and{
 throws_ok{
     @ARGV = qw(--x --y=3.14);
     $foo->bar;
-} qr/Value "3.14" invalid for option y \(number expected\)/;
+} qr/Value "3.14" invalid for option y \((integer )?number expected\)/;
 
 done_testing;


### PR DESCRIPTION
After upgrading Getopt-Long from 2.57 to 2.58, the tests failed liked this:

    #   Failed test 'threw Regexp ((?^:Value "3.14" invalid for option y \(number expected\)))'
    #   at t/010_simple/06_required_tc.t line 46.
    # expecting: Regexp ((?^:Value "3.14" invalid for option y \(number expected\)))
    # found: Value "3.14" invalid for option y (integer number expected)
    #  at t/010_simple/06_required_tc.t line 16.
    # Looks like you failed 1 test of 7.
    t/010_simple/06_required_tc.t ............
    Dubious, test returned 1 (wstat 256, 0x100)
    Failed 1/7 subtests

The cause was that Getopt-Long-2.58 intentionally changed a message about expecting a number <https://github.com/sciurius/perl-Getopt-Long/issues/26>.

This patch adjusts the tests to accept both old and new wording.